### PR TITLE
Wordplay form detectors for the purple category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ z3
 gensim
 numpy
 sentence-transformers
+english-words
+pronouncing
+wordfreq

--- a/test_wordplay_bot.py
+++ b/test_wordplay_bot.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import argparse
+import random
+from dataclasses import dataclass
+from pathlib import Path
+
+from test_connection_bot import DEFAULT_DATA_PATH, Puzzle, load_puzzles, score_guess
+from word_embeddings import SentenceTransformerEmbedder
+from wordplay_bot import DEFAULT_FORM_WEIGHT, WordplayConnectionBot, _best_trusted_form
+
+STARTING_MISTAKES = 4
+Correctness = WordplayConnectionBot.Correctness
+
+
+@dataclass
+class Outcome:
+    won: bool
+    groups_solved: int
+    mistakes: int
+    form_guesses: int = 0          # guesses made on a group with a 4/4 form match
+    form_guesses_correct: int = 0  # of those, how many were a real group
+
+
+@dataclass
+class Tally:
+    wins: int = 0
+    games: int = 0
+    mistakes: int = 0
+    groups_solved: int = 0
+
+    def add(self, outcome: Outcome) -> None:
+        self.games += 1
+        self.wins += int(outcome.won)
+        self.mistakes += outcome.mistakes
+        self.groups_solved += outcome.groups_solved
+
+    @property
+    def win_rate(self) -> float:
+        return self.wins / self.games if self.games else 0.0
+
+    @property
+    def avg_mistakes(self) -> float:
+        return self.mistakes / self.games if self.games else 0.0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare the embedding bot against the embedding + wordplay bot."
+    )
+    parser.add_argument("--data-path", type=Path, default=DEFAULT_DATA_PATH)
+    parser.add_argument("--limit", type=int, default=50,
+                        help="Number of puzzles to run. Default: 50.")
+    parser.add_argument("--seed", type=int, default=0,
+                        help="Seed for the puzzle sample. Default: 0.")
+    parser.add_argument("--form-weight", type=float, default=DEFAULT_FORM_WEIGHT,
+                        help=f"Form weight for the wordplay bot. Default: {DEFAULT_FORM_WEIGHT}.")
+    parser.add_argument("--wordplay-only", action="store_true",
+                        help="Only run puzzles that contain a trusted-detector wordplay group.")
+    return parser.parse_args()
+
+
+def true_groups(puzzle: Puzzle) -> list[list[str]]:
+    groups: dict[str, list[str]] = {}
+    for word in puzzle.words:
+        groups.setdefault(puzzle.word_to_group[word], []).append(word)
+    return list(groups.values())
+
+
+def has_covered_wordplay(puzzle: Puzzle) -> bool:
+    """True if one of the four real groups is a trusted wordplay pattern."""
+    return any(_best_trusted_form(group).score >= 1.0 for group in true_groups(puzzle))
+
+
+def play(puzzle: Puzzle, embedder, form_weight: float) -> Outcome:
+    bot = WordplayConnectionBot(puzzle.words, embedder=embedder, form_weight=form_weight)
+    solved: set[str] = set()
+    mistakes = 0
+    form_guesses = 0
+    form_correct = 0
+
+    while mistakes < STARTING_MISTAKES and len(solved) < 3:
+        guess = bot.get_guess()
+        used_form = bot.last_form is not None and bot.last_form.score >= bot.form_threshold
+        correctness, group = score_guess(guess, puzzle.word_to_group, WordplayConnectionBot)
+        bot.add_guess_result(guess, correctness)
+
+        correct = correctness == Correctness.Correct
+        if used_form:
+            form_guesses += 1
+            form_correct += int(correct)
+        if correct and group is not None:
+            solved.add(group)
+        elif not correct:
+            mistakes += 1
+
+    return Outcome(len(solved) >= 3, len(solved), mistakes, form_guesses, form_correct)
+
+
+def print_report(baseline: Tally, wordplay: Tally, wp_baseline: Tally, wp_wordplay: Tally,
+                 form_guesses: int, form_correct: int) -> None:
+    def column(name: str, base: Tally, form: Tally) -> None:
+        print(f"\n{name} ({base.games} puzzles)")
+        print(f"  {'':<20}{'baseline':>12}{'+ wordplay':>12}")
+        print(f"  {'wins':<20}{base.wins:>12}{form.wins:>12}")
+        print(f"  {'win rate':<20}{base.win_rate:>11.1%}{form.win_rate:>12.1%}")
+        print(f"  {'avg mistakes':<20}{base.avg_mistakes:>12.2f}{form.avg_mistakes:>12.2f}")
+        print(f"  {'groups solved':<20}{base.groups_solved:>12}{form.groups_solved:>12}")
+
+    print("\nEmbedding bot vs. embedding + wordplay bot")
+    print("==========================================")
+    column("All puzzles", baseline, wordplay)
+    column("Puzzles with a detectable wordplay group", wp_baseline, wp_wordplay)
+
+    precision = form_correct / form_guesses if form_guesses else 0.0
+    print("\nForm-driven guesses (the bot guessed a group on a 4/4 form match):")
+    print(f"  {form_correct}/{form_guesses} were a real group ({precision:.0%} precision)")
+
+
+def main() -> None:
+    args = parse_args()
+    puzzles = load_puzzles(args.data_path)
+    if args.wordplay_only:
+        puzzles = [puzzle for puzzle in puzzles if has_covered_wordplay(puzzle)]
+        print(f"Found {len(puzzles)} puzzles with a trusted-detector wordplay group.")
+    else:
+        random.seed(args.seed)
+        random.shuffle(puzzles)
+        puzzles = puzzles[: args.limit]
+
+    embedder = SentenceTransformerEmbedder()
+    embedder.embed_texts(["warmup"])  # load the model once before timing games
+
+    baseline = Tally()
+    wordplay = Tally()
+    wp_baseline = Tally()
+    wp_wordplay = Tally()
+    form_guesses = 0
+    form_correct = 0
+
+    for index, puzzle in enumerate(puzzles, start=1):
+        base_outcome = play(puzzle, embedder, form_weight=0.0)
+        form_outcome = play(puzzle, embedder, form_weight=args.form_weight)
+        baseline.add(base_outcome)
+        wordplay.add(form_outcome)
+        form_guesses += form_outcome.form_guesses
+        form_correct += form_outcome.form_guesses_correct
+
+        if has_covered_wordplay(puzzle):
+            wp_baseline.add(base_outcome)
+            wp_wordplay.add(form_outcome)
+
+        if index % 10 == 0:
+            print(f"  played {index}/{len(puzzles)} puzzles...")
+
+    print_report(baseline, wordplay, wp_baseline, wp_wordplay, form_guesses, form_correct)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_wordplay_detectors.py
+++ b/test_wordplay_detectors.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+
+from wordplay_detectors import (
+    GROUP_SIZE,
+    detect_hidden_word,
+    detect_homophone,
+    detect_letter_add_drop,
+    detect_mutual_anagram,
+    detect_one_letter_off,
+    detect_scrambled_word,
+    score_group,
+)
+
+
+DEFAULT_DATA_PATH = Path(__file__).resolve().parent / "data" / "Connections_Data.parquet"
+
+# A group "fires" when at least three of its four words fit the pattern.
+FIRE_THRESHOLD = 0.75
+
+DETECTOR_BY_PATTERN = {
+    "mutual anagram": detect_mutual_anagram,
+    "scrambled word": detect_scrambled_word,
+    "add a letter": detect_letter_add_drop,
+    "drop a letter": detect_letter_add_drop,
+    "one letter off": detect_one_letter_off,
+    "hidden word": detect_hidden_word,
+    "homophone": detect_homophone,
+}
+
+# Purple-style groups that should fire, with the pattern and minimum score
+# each one is expected to produce.
+POSITIVE_CASES = [
+    ("mutual anagram", ["LISTEN", "SILENT", "ENLIST", "TINSEL"], 1.0),
+    ("scrambled word", ["EARTH", "BELOW", "REACT", "ANGEL"], 1.0),
+    ("drop a letter", ["BREAD", "SPILL", "TRACE", "CLOVER"], 1.0),
+    ("add a letter", ["RIGHT", "OIL", "RAIN", "EACH"], 1.0),
+    ("one letter off", ["HOUSE", "BEER", "GOAL", "WARM"], 1.0),
+    ("hidden word", ["CHIPMUNK", "SPEARMINT", "CHARM", "SHINGLE"], 1.0),
+    ("homophone", ["BEE", "SEA", "JAY", "CUE"], 1.0),
+    ("homophone", ["WON", "ATE", "FOR", "TOO"], 1.0),
+    # 3/4 partial match: the odd word out should drag the score to 0.75.
+    ("hidden word", ["CHIPMUNK", "SPEARMINT", "CHARM", "BUCKET"], 0.75),
+]
+
+# Meaning-based groups from real puzzles that no form detector should fire on.
+NEGATIVE_CASES = [
+    ("wet weather", ["SNOW", "HAIL", "SLEET", "RAIN"]),
+    ("nba teams", ["HEAT", "BUCKS", "JAZZ", "NETS"]),
+    ("keyboard keys", ["SHIFT", "TAB", "RETURN", "OPTION"]),
+    ("magazines", ["TIME", "PEOPLE", "ESSENCE", "US"]),
+    ("footwear", ["BOOT", "SANDAL", "SLIPPER", "LOAFER"]),
+    ("moods", ["ANGRY", "GRUMPY", "JOLLY", "MOODY"]),
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the wordplay detector fixture tests."
+    )
+    parser.add_argument(
+        "--history",
+        action="store_true",
+        help="Also score every historical group and report fire rates by level.",
+    )
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to the Connections parquet data. Default: {DEFAULT_DATA_PATH}",
+    )
+    return parser.parse_args()
+
+
+def run_positive_cases() -> list[str]:
+    failures = []
+    for expected_pattern, words, min_score in POSITIVE_CASES:
+        result = score_group(words)
+        detector_result = DETECTOR_BY_PATTERN[expected_pattern](words)
+        if result.pattern != expected_pattern or result.score < min_score:
+            failures.append(
+                f"expected {expected_pattern} >= {min_score} for {words}, "
+                f"got: {result.explain()}"
+            )
+        elif detector_result.score < min_score:
+            failures.append(
+                f"{expected_pattern} detector alone scored {detector_result.score} "
+                f"on {words}, expected >= {min_score}"
+            )
+        else:
+            print(f"  pass: {result.explain()}")
+    return failures
+
+
+def run_negative_cases() -> list[str]:
+    failures = []
+    for label, words in NEGATIVE_CASES:
+        result = score_group(words)
+        if result.score >= FIRE_THRESHOLD:
+            failures.append(f"{label} {words} should stay quiet, got: {result.explain()}")
+        else:
+            print(f"  pass: {label} stayed quiet (best was {result.explain()})")
+    return failures
+
+
+def load_groups(data_path: Path) -> list[tuple[int, list[str]]]:
+    import pandas as pd
+
+    data = pd.read_parquet(data_path)
+    groups = []
+    for _, rows in data.groupby(["Game ID", "Group Name"]):
+        words = rows["Word"].astype(str).tolist()
+        if len(words) == GROUP_SIZE:
+            groups.append((int(rows["Group Level"].iloc[0]), words))
+    return groups
+
+
+def run_history(data_path: Path) -> None:
+    groups = load_groups(data_path)
+    partial_by_level: Counter[int] = Counter()
+    full_by_level: Counter[int] = Counter()
+    total_by_level: Counter[int] = Counter()
+    examples: list[str] = []
+
+    for level, words in groups:
+        total_by_level[level] += 1
+        result = score_group(words)
+        if result.score >= FIRE_THRESHOLD:
+            partial_by_level[level] += 1
+        if result.score >= 1.0:
+            full_by_level[level] += 1
+            if level == 3 and len(examples) < 10:
+                examples.append(result.explain())
+
+    # Level 3 is the purple row. A signal that measures wordplay should fire
+    # more often as the level climbs, and most of all on purple.
+    print("\nFire rate on historical groups, by difficulty level:")
+    print(f"  {'level':>7}  {'>= ' + str(FIRE_THRESHOLD) + ' (3/4)':>14}  {'== 1.0 (4/4)':>14}")
+    for level in sorted(total_by_level):
+        total = total_by_level[level]
+        partial = partial_by_level[level]
+        full = full_by_level[level]
+        print(f"  {level:>7}  {partial:4d}/{total} ({partial / total:5.1%})  "
+              f"{full:4d}/{total} ({full / total:5.1%})")
+
+    full_total = sum(full_by_level.values())
+    if full_total:
+        purple_share = full_by_level[3] / full_total
+        print(f"\n  Purple's share of full (4/4) fires: {full_by_level[3]}/{full_total} "
+              f"({purple_share:.0%}) against a 25% base rate.")
+
+    print("\nSample purple groups caught at full strength:")
+    for example in examples:
+        print(f"  {example}")
+
+
+def main() -> None:
+    args = parse_args()
+
+    print("Positive cases (purple groups that should fire):")
+    failures = run_positive_cases()
+    print("\nNegative cases (semantic groups that should stay quiet):")
+    failures += run_negative_cases()
+
+    if failures:
+        print(f"\n{len(failures)} FAILURE(S):")
+        for failure in failures:
+            print(f"  {failure}")
+    else:
+        print(f"\nAll {len(POSITIVE_CASES) + len(NEGATIVE_CASES)} fixture cases passed.")
+
+    if args.history:
+        run_history(args.data_path)
+
+    if failures:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/wordplay_bot.py
+++ b/wordplay_bot.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from enum import Enum
+from itertools import combinations
+
+from bin_embeddings import _total_pairwise_cosine_distance
+from guessed_constraints import PrevConstraint
+from word_embeddings import SentenceTransformerEmbedder, TextEmbedder
+from wordplay_detectors import (
+    WordplayResult,
+    detect_homophone,
+    detect_mutual_anagram,
+    detect_one_letter_off,
+)
+
+# A puzzle has 1820 possible groups of four, and the looser detectors (scrambled
+# word, add/drop a letter, hidden word) match some coincidental subset almost
+# every game -- measured under 1% precision as a group predictor. Only the tightly
+# constrained detectors are safe to actually drive a guess, so the bot ranks groups
+# with just these three. The full six-detector score_group is still the right call
+# for explaining a group we already trust to the judge.
+TRUSTED_DETECTORS = (detect_mutual_anagram, detect_one_letter_off, detect_homophone)
+
+# How hard a form match pulls a group up the ranking: a qualifying match drops a
+# group's effective distance by this much. Set to 0 for the plain embedding bot.
+DEFAULT_FORM_WEIGHT = 1.0
+
+# Only let a group's form score count once it is at least this strong. A full 4/4
+# match from a trusted detector is reliable; 3/4 is mostly coincidence, so by
+# default only full matches help.
+DEFAULT_FORM_THRESHOLD = 1.0
+
+
+def _best_trusted_form(words: list[str]) -> WordplayResult:
+    return max((detector(words) for detector in TRUSTED_DETECTORS),
+               key=lambda result: result.score)
+
+
+class WordplayConnectionBot:
+    class Correctness(Enum):
+        FullyWrong = PrevConstraint.Correctness.FullyWrong
+        OneOff = PrevConstraint.Correctness.OneOff
+        Correct = PrevConstraint.Correctness.Correct
+
+    def __init__(
+        self,
+        words: list[str],
+        embedder: TextEmbedder | None = None,
+        form_weight: float = DEFAULT_FORM_WEIGHT,
+        form_threshold: float = DEFAULT_FORM_THRESHOLD,
+    ) -> None:
+        if len(words) != 16 or len(set(words)) != 16:
+            raise ValueError("WordplayConnectionBot needs 16 unique words!")
+
+        self.words = list(words)
+        self.form_weight = form_weight
+        self.form_threshold = form_threshold
+        self.constraints = PrevConstraint(words)
+        self.bad_guesses: list[frozenset[str]] = []
+        self.last_form: WordplayResult | None = None
+
+        if embedder is None:
+            embedder = SentenceTransformerEmbedder()
+        vectors = embedder.embed_texts(self.words)
+        position = {word: index for index, word in enumerate(self.words)}
+
+        # Embedding distance and form score don't change as the game goes on, so
+        # score every group of four once here and just filter the survivors later.
+        self.distance: dict[frozenset[str], float] = {}
+        self.form: dict[frozenset[str], WordplayResult] = {}
+        for group in combinations(self.words, 4):
+            key = frozenset(group)
+            indices = tuple(position[word] for word in group)
+            self.distance[key] = _total_pairwise_cosine_distance(indices, vectors)
+            self.form[key] = _best_trusted_form(list(group))
+
+    def _combined_score(self, key: frozenset[str]) -> float:
+        form = self.form[key].score
+        bonus = form if form >= self.form_threshold else 0.0
+        return self.distance[key] - self.form_weight * bonus
+
+    def get_guess(self) -> list[str]:
+        if not self.words:
+            raise ValueError("WordplayConnectionBot has no words left to guess.")
+
+        already_wrong = set(self.bad_guesses)
+        candidates = [
+            frozenset(group)
+            for group in combinations(self.words, 4)
+            if frozenset(group) not in already_wrong
+        ]
+        candidates.sort(key=self._combined_score)
+
+        for key in candidates:
+            guess = [word for word in self.words if word in key]
+            if self.constraints.is_possible(guess[0], guess[1], guess[2], guess[3]):
+                self.last_form = self.form[key]
+                return guess
+            self.bad_guesses.append(key)
+
+        raise ValueError("Every remaining group has been ruled out.")
+
+    def add_guess_result(self, guess: list[str], correctness: Correctness) -> None:
+        self.constraints.add_guess(guess[0], guess[1], guess[2], guess[3], correctness.value)
+        self.bad_guesses.append(frozenset(guess))
+        if correctness == self.Correctness.Correct:
+            solved = set(guess)
+            self.words = [word for word in self.words if word not in solved]

--- a/wordplay_detectors.py
+++ b/wordplay_detectors.py
@@ -1,0 +1,358 @@
+# Form-based wordplay detectors for the purple Connections category.
+#
+# The embedding and constraint signals reason about what words mean, so they
+# cannot see categories built on spelling or sound (anagrams, hidden words,
+# homophones). Each detector here checks one mechanical pattern over a group
+# of four words and reports the fraction that pass along with per-word
+# evidence, so the rest of the solver can see why a pattern fired.
+#
+# Known limitations:
+#   - The themed detectors (one letter off, hidden word, homophone) can only
+#     find categories whose theme appears in THEME_SETS below.
+#   - Scramble targets and letter-edit results are gated by word frequency,
+#     so a pattern built on an obscure word will be missed.
+#   - Homophone coverage is limited to what the CMU dictionary knows.
+#   - Theme words made of common letter runs (red, ant, rat) can show up
+#     inside unrelated words and cause hidden-word false hits.
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from functools import lru_cache
+import re
+import string
+
+GROUP_SIZE = 4
+MIN_SCRAMBLE_LENGTH = 4
+MIN_EDIT_RESULT_LENGTH = 4
+MIN_HIDDEN_LENGTH = 3
+MIN_ZIPF_FREQUENCY = 3.2
+
+# Edits at the end of a word that just inflect it (plurals, past tense, -y
+# adjectives) say nothing about wordplay, so they never count as matches.
+INFLECTION_LETTERS = frozenset("sdy")
+
+# The web2 list contains slurs, and an anagram or scramble lookup will happily
+# surface one as a "rearranges to ..." target in the evidence text. They are
+# dropped from the dictionary so they can never appear in output. This list is
+# deliberately small and is not meant to be an exhaustive profanity filter.
+BLOCKED_WORDS = frozenset({
+    "nigger", "niger", "negress", "coon", "spic", "spick", "chink", "gook",
+    "kike", "wop", "dago", "wetback", "beaner", "kraut", "jap", "redskin",
+    "gyp", "fag", "faggot", "dyke", "tranny", "retard", "retarded", "spaz",
+    "cripple", "midget", "mongoloid",
+})
+
+_STRESS_RE = re.compile(r"\d")
+
+# Themed detectors can only find categories listed here -- extend as needed.
+THEME_SETS: dict[str, frozenset[str]] = {
+    "body parts": frozenset({
+        "arm", "ear", "eye", "hip", "jaw", "leg", "lip", "rib", "toe", "gum",
+        "gut", "shin", "chin", "knee", "heel", "nose", "brow", "calf", "hand",
+        "foot", "neck", "back", "spine", "thigh", "wrist", "ankle", "elbow",
+        "thumb",
+    }),
+    "animals": frozenset({
+        "ant", "ape", "asp", "bat", "bee", "boa", "cat", "cow", "doe", "dog",
+        "eel", "elk", "emu", "ewe", "fox", "hen", "hog", "owl", "pig", "ram",
+        "rat", "sow", "yak", "bear", "bird", "crab", "crow", "deer", "duck",
+        "fish", "frog", "goat", "hare", "hawk", "lamb", "lion", "mole", "mule",
+        "newt", "pony", "seal", "slug", "swan", "toad", "wasp", "wolf", "worm",
+        "moose", "mouse", "sheep", "snake",
+    }),
+    "colors": frozenset({
+        "red", "tan", "blue", "cyan", "gold", "gray", "grey", "jade", "pink",
+        "plum", "rust", "teal", "amber", "beige", "black", "brown", "coral",
+        "green", "ivory", "olive", "peach", "white", "indigo", "maroon",
+        "orange", "purple", "violet", "yellow", "scarlet",
+    }),
+    "numbers": frozenset({
+        "one", "two", "six", "ten", "zero", "four", "five", "nine", "three",
+        "seven", "eight", "eleven", "twelve", "twenty", "thirty", "forty",
+        "fifty", "sixty", "hundred", "thousand",
+    }),
+    "trees": frozenset({
+        "oak", "elm", "fir", "ash", "yew", "pine", "palm", "aspen", "beech",
+        "birch", "cedar", "maple", "spruce", "willow",
+    }),
+    "fruits": frozenset({
+        "fig", "date", "kiwi", "lime", "pear", "plum", "apple", "grape",
+        "lemon", "mango", "melon", "peach", "banana", "cherry",
+    }),
+    "metals": frozenset({
+        "tin", "gold", "iron", "lead", "zinc", "brass", "steel", "bronze",
+        "copper", "nickel", "silver",
+    }),
+}
+
+LETTER_NAMES = frozenset(string.ascii_lowercase)
+
+
+@dataclass(frozen=True)
+class WordplayResult:
+    pattern: str
+    score: float
+    matches: dict[str, str]
+    theme: str | None = None
+
+    def explain(self) -> str:
+        if not self.matches:
+            return f"{self.pattern}: 0/{GROUP_SIZE} words matched"
+        details = "; ".join(
+            f"{word} {detail}" for word, detail in sorted(self.matches.items())
+        )
+        theme_note = f" ({self.theme})" if self.theme else ""
+        return (
+            f"{self.pattern}{theme_note}: "
+            f"{len(self.matches)}/{GROUP_SIZE} words matched - {details}"
+        )
+
+
+@lru_cache(maxsize=1)
+def load_dictionary() -> frozenset[str]:
+    """Load the web2 word list, keeping only reasonably common words."""
+    from english_words import get_english_words_set
+    from wordfreq import zipf_frequency
+
+    web2 = get_english_words_set(["web2"], alpha=True, lower=True)
+    return frozenset(
+        word
+        for word in web2
+        if word not in BLOCKED_WORDS and zipf_frequency(word, "en") >= MIN_ZIPF_FREQUENCY
+    )
+
+
+@lru_cache(maxsize=1)
+def load_signature_index() -> dict[str, frozenset[str]]:
+    """Map each sorted-letters signature to the dictionary words that share it."""
+    index: dict[str, set[str]] = {}
+    for word in load_dictionary():
+        index.setdefault("".join(sorted(word)), set()).add(word)
+    return {signature: frozenset(words) for signature, words in index.items()}
+
+
+@lru_cache(maxsize=1)
+def load_homophone_targets() -> dict[str, list[tuple[str, str]]]:
+    """Map stress-stripped CMU pronunciations to (theme, target word) pairs."""
+    import pronouncing
+
+    themes: dict[str, frozenset[str]] = {"letters": LETTER_NAMES, **THEME_SETS}
+    targets: dict[str, list[tuple[str, str]]] = {}
+    for theme, members in themes.items():
+        for member in sorted(members):
+            for phones in pronouncing.phones_for_word(member):
+                targets.setdefault(_strip_stress(phones), []).append((theme, member))
+    return targets
+
+
+def _validate_group(words: list[str]) -> list[str]:
+    if len(words) != GROUP_SIZE or len(set(words)) != GROUP_SIZE:
+        raise ValueError(f"wordplay detectors need {GROUP_SIZE} unique words")
+    return [word.strip().lower() for word in words]
+
+
+def _strip_stress(phones: str) -> str:
+    return _STRESS_RE.sub("", phones)
+
+
+def _hamming_distance(left: str, right: str) -> int:
+    return sum(1 for a, b in zip(left, right) if a != b)
+
+
+def _position_label(index: int, last_index: int) -> str:
+    if index == 0:
+        return "first"
+    if index == last_index:
+        return "last"
+    return "middle"
+
+
+def _one_letter_edits(word: str) -> list[tuple[str, str, str, str]]:
+    """List every (operation, position, letter, result) edit that makes a word."""
+    dictionary = load_dictionary()
+    edits = []
+    for index, letter in enumerate(word):
+        position = _position_label(index, len(word) - 1)
+        if position == "last" and letter in INFLECTION_LETTERS:
+            continue
+        result = word[:index] + word[index + 1:]
+        if len(result) >= MIN_EDIT_RESULT_LENGTH and result in dictionary:
+            edits.append(("drop", position, letter, result))
+    for index in range(len(word) + 1):
+        position = _position_label(index, len(word))
+        for letter in string.ascii_lowercase:
+            if position == "last" and letter in INFLECTION_LETTERS:
+                continue
+            result = word[:index] + letter + word[index:]
+            if len(result) >= MIN_EDIT_RESULT_LENGTH and result in dictionary:
+                edits.append(("add", position, letter, result))
+    return edits
+
+
+def detect_mutual_anagram(words: list[str]) -> WordplayResult:
+    """Score how many of the four words are rearrangements of each other."""
+    normalized = _validate_group(words)
+    signatures = {
+        word: "".join(sorted(word)) for word in normalized if word.isalpha()
+    }
+    counts = Counter(signatures.values())
+    if not counts or max(counts.values()) < 2:
+        return WordplayResult("mutual anagram", 0.0, {})
+    best_signature = counts.most_common(1)[0][0]
+    matched = sorted(word for word, sig in signatures.items() if sig == best_signature)
+    matches = {
+        word: f"has the same letters as {', '.join(o for o in matched if o != word)}"
+        for word in matched
+    }
+    return WordplayResult("mutual anagram", len(matched) / GROUP_SIZE, matches)
+
+
+def detect_scrambled_word(words: list[str]) -> WordplayResult:
+    """Score how many words rearrange into a different dictionary word."""
+    normalized = _validate_group(words)
+    index = load_signature_index()
+    matches: dict[str, str] = {}
+    for word in normalized:
+        if not word.isalpha() or len(word) < MIN_SCRAMBLE_LENGTH:
+            continue
+        rearrangements = index.get("".join(sorted(word)), frozenset()) - {word}
+        if rearrangements:
+            examples = ", ".join(sorted(rearrangements)[:3])
+            matches[word] = f"rearranges to {examples}"
+    return WordplayResult("scrambled word", len(matches) / GROUP_SIZE, matches)
+
+
+def detect_letter_add_drop(words: list[str]) -> WordplayResult:
+    """Score how many words make a new word by adding or dropping one letter.
+
+    Edits only count toward the score when they agree on a shared pattern
+    (same operation and position, or same operation and letter), so a group
+    where every word happens to shed some unrelated letter stays quiet.
+    """
+    normalized = _validate_group(words)
+    grouped: dict[tuple[str, str, str], dict[str, str]] = {}
+    for word in normalized:
+        if not word.isalpha():
+            continue
+        for operation, position, letter, result in _one_letter_edits(word):
+            sign = "+" if operation == "add" else "-"
+            detail = f"{sign}{letter} -> {result}"
+            keys = [(operation, "letter", letter)]
+            if position != "middle":
+                keys.append((operation, "position", position))
+            for key in keys:
+                grouped.setdefault(key, {}).setdefault(word, detail)
+    if not grouped:
+        return WordplayResult("add or drop a letter", 0.0, {})
+    best_key, matches = max(grouped.items(), key=lambda item: (len(item[1]), item[0]))
+    operation, kind, value = best_key
+    if kind == "position":
+        theme = f"{operation} the {value} letter"
+    else:
+        theme = f"{operation} the letter '{value}'"
+    pattern = "add a letter" if operation == "add" else "drop a letter"
+    return WordplayResult(pattern, len(matches) / GROUP_SIZE, matches, theme)
+
+
+def detect_one_letter_off(words: list[str]) -> WordplayResult:
+    """Score how many words are one substituted letter away from a themed word."""
+    normalized = _validate_group(words)
+    best_theme: str | None = None
+    best_matches: dict[str, str] = {}
+    for theme, members in THEME_SETS.items():
+        matches: dict[str, str] = {}
+        for word in normalized:
+            if not word.isalpha() or word in members:
+                continue
+            targets = sorted(
+                member
+                for member in members
+                if len(member) == len(word) and _hamming_distance(member, word) == 1
+            )
+            if targets:
+                matches[word] = f"is one letter from {targets[0]}"
+        if len(matches) > len(best_matches):
+            best_theme, best_matches = theme, matches
+    return WordplayResult(
+        "one letter off", len(best_matches) / GROUP_SIZE, best_matches, best_theme
+    )
+
+
+def detect_hidden_word(words: list[str]) -> WordplayResult:
+    """Score how many words contain a smaller themed word inside them."""
+    normalized = _validate_group(words)
+    best_theme: str | None = None
+    best_matches: dict[str, str] = {}
+    for theme, members in THEME_SETS.items():
+        matches: dict[str, str] = {}
+        for word in normalized:
+            letters = "".join(ch for ch in word if ch.isalpha())
+            found = [
+                member
+                for member in members
+                if len(member) >= MIN_HIDDEN_LENGTH
+                and len(letters) > len(member)
+                and member in letters
+            ]
+            if found:
+                matches[word] = f"contains {max(sorted(found), key=len)}"
+        if len(matches) > len(best_matches):
+            best_theme, best_matches = theme, matches
+    return WordplayResult(
+        "hidden word", len(best_matches) / GROUP_SIZE, best_matches, best_theme
+    )
+
+
+def detect_homophone(words: list[str]) -> WordplayResult:
+    """Score how many words sound exactly like a themed word or letter name."""
+    import pronouncing
+
+    normalized = _validate_group(words)
+    targets_by_phones = load_homophone_targets()
+    theme_matches: dict[str, dict[str, str]] = {}
+    for word in normalized:
+        if not word.isalpha():
+            continue
+        for phones in pronouncing.phones_for_word(word):
+            for theme, target in targets_by_phones.get(_strip_stress(phones), []):
+                if target == word:
+                    continue
+                if theme == "letters":
+                    detail = f"sounds like the letter {target.upper()}"
+                else:
+                    detail = f"sounds like {target}"
+                theme_matches.setdefault(theme, {}).setdefault(word, detail)
+    if not theme_matches:
+        return WordplayResult("homophone", 0.0, {})
+    best_theme, best_matches = max(
+        theme_matches.items(), key=lambda item: (len(item[1]), item[0])
+    )
+    return WordplayResult(
+        "homophone", len(best_matches) / GROUP_SIZE, best_matches, best_theme
+    )
+
+
+ALL_DETECTORS = [
+    detect_mutual_anagram,
+    detect_scrambled_word,
+    detect_letter_add_drop,
+    detect_one_letter_off,
+    detect_hidden_word,
+    detect_homophone,
+]
+
+
+def score_group(words: list[str]) -> WordplayResult:
+    """Run every detector on a group of four and return the strongest match.
+
+    Scores are the fraction of the group that fits the pattern, so 1.0 means
+    all four words match and 0.75 is a weak signal that the odd word out may
+    belong somewhere else. Earlier detectors in ALL_DETECTORS win ties, so
+    tighter patterns (mutual anagram) beat looser ones at the same score.
+    """
+    return max(
+        (detector(words) for detector in ALL_DETECTORS),
+        key=lambda result: result.score,
+    )


### PR DESCRIPTION
This adds the form-based signal for the purple category. The embedding and constraint signals all reason about meaning, so they're blind to categories built on spelling or sound (anagrams, hidden words, homophones). This module checks six mechanical patterns over a group of four words and reports the fraction that match plus per-word evidence.

## Detectors (`wordplay_detectors.py`)
- mutual anagram — LISTEN / SILENT / ENLIST / TINSEL
- scrambled word — EARTH -> HEART, REACT -> TRACE
- add / drop a letter — BREAD - B -> READ
- one letter off a themed target — MOOSE -> MOUSE (animals)
- hidden themed word — cHIPmunk, spEARmint (body parts)
- homophone via the CMU dict — BEE -> "B", ATE -> "eight"

The last three lean on small theme sets (body parts, animals, colors, numbers, trees, fruits, metals, single-letter homophones) in `THEME_SETS`. They can only find a category whose theme is in that list — easy to extend, but that's the main limitation, called out in the module header.

## How to wire it in
`score_group(words)` runs all six detectors on a group of four and returns the strongest as a `WordplayResult`:
- `.score` — fraction of the four that fit the pattern (0.0, 0.25, ... 1.0)
- `.pattern`, `.theme` — which pattern fired and the inferred theme
- `.explain()` — human-readable evidence string for the LLM judge / writeup

Call it on each candidate group. Note `.score` is higher = stronger, the opposite of the embedding cosine distance, so flip it (`1 - score`) if you feed it into the same lowest-distance comparison in `connection_bot.py`. The intended use is a tie-breaker: when the meaning signals are split or weak but one detector hits 1.0 across all four words, that group is almost certainly the purple one. I left `connection_bot.py` untouched so you can decide where it slots in.

## Validation
Scored every group in the dataset (`python test_wordplay_detectors.py --history`). The full 4/4 fire rate climbs with difficulty and concentrates on purple:

| level | 4/4 fire rate |
|-------|---------------|
| 0 | 0.2% |
| 1 | 0.5% |
| 2 | 1.0% |
| 3 (purple) | 1.9% |

52% of all 4/4 fires land on the purple row against a 25% base rate. `python test_wordplay_detectors.py` runs the fixtures: a positive case per detector (plus a 3/4 partial) and semantic negatives (wet weather, NBA teams, etc.) that have to stay quiet.

## Notes
- Dictionary is the web2 list filtered to wordfreq zipf >= 3.2 so obscure junk doesn't create fake anagram/edit matches, minus a small slur blocklist so the evidence text stays clean.
- New deps in requirements.txt: english-words, pronouncing, wordfreq.
